### PR TITLE
Types and tests for VideoToImage module

### DIFF
--- a/ascii-vid-generator.cabal
+++ b/ascii-vid-generator.cabal
@@ -90,6 +90,8 @@ library
       common-stanza
   exposed-modules:
       Lib
+      Variables
+      VideoToImage
   hs-source-dirs:
       src
   default-language: Haskell2010
@@ -121,4 +123,5 @@ test-suite ascii-vid-generator-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       ascii-vid-generator
-
+  other-modules:
+      VideoToImageTest

--- a/src/Variables.hs
+++ b/src/Variables.hs
@@ -28,6 +28,9 @@ Getter of the path of image file.
 Args:
     - the index of the image. Note that this is just a formatter to produce
       the file path. It does not check if such file exists.
+
+Returns:
+    - path of the image
 -}
 imageFile :: Int -> FilePath
 imageFile n = tempDir </> show n <.> "png"

--- a/src/VideoToImage.hs
+++ b/src/VideoToImage.hs
@@ -1,0 +1,42 @@
+{-
+This module contains all the auxiliary function to invoke ffmpeg
+and convert the target video to png files, saved in a temporary working directory.
+-}
+
+module VideoToImage where
+
+import System.Process
+import System.FilePath
+
+import qualified Variables
+
+
+{-
+Generate the images from the video at the temporary directory.
+
+Args:
+    - file path of the video
+    - fps
+
+Returns:
+    - Either
+        - error message
+        - (), unit representing success
+-}
+generateImages :: FilePath -> Int -> IO (Either String ())
+generateImages = undefined
+
+
+
+{-
+Generate the command to execute for video to image generation
+
+Args:
+    - file path of the video
+    - FPS
+
+Returns:
+    - Tuple of the arguments that are ready to be passed in `readProcessWithExitCode`
+-}
+getFFmpegCommand :: FilePath -> Int -> (String, [String], String)
+getFFmpegCommand = undefined

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,5 +1,8 @@
 import Test.HUnit
 import Test.QuickCheck
 
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+import VideoToImageTest
+
+main :: IO Counts
+main = do
+    runVideoToImageTests

--- a/test/VideoToImageTest.hs
+++ b/test/VideoToImageTest.hs
@@ -1,0 +1,23 @@
+module VideoToImageTest where
+
+import Test.HUnit
+import Test.QuickCheck
+import VideoToImage (getFFmpegCommand)
+import Variables (imageFileFFmpegFormat)
+
+
+test_getFFmpegCommand :: Test
+test_getFFmpegCommand =
+    TestList [
+        getFFmpegCommand "video.mp4" 10 ~?=
+            ("ffmpeg", ["-i", "video.mp4", "-vf", "fps=10", imageFileFFmpegFormat], ""),
+
+        getFFmpegCommand "video.flv" 1 ~?=
+            ("ffmpeg", ["-i", "video.flv", "-vf", "fps=1", imageFileFFmpegFormat], "")
+    ]
+
+runVideoToImageTests :: IO Counts
+runVideoToImageTests = runTestTT $
+    TestList [
+        test_getFFmpegCommand
+    ]


### PR DESCRIPTION
A simple module to invoke FFmpeg in a subprocess to create images from the given video.

Two questions:

1. Any idea on how to test the `IO` related function - `generateImages`?
2. In the terminal, `stack test` compiles successfully and outputs the test failed messages (as they are undefined yet). However, in my VSCode, In `test/Spec.hs`, I'm getting this import error:

![image](https://user-images.githubusercontent.com/34412510/201437284-c7f11c7c-40ee-489e-a406-8b3dbb6ae33d.png)

It's technically not a problem... But just annoying. Any idea how to resolve this?
